### PR TITLE
Add a _src param to all API requests.

### DIFF
--- a/google-analytics-chart.html
+++ b/google-analytics-chart.html
@@ -94,8 +94,6 @@ Google Chart.
          */
         options: null,
 
-        output: 'dataTable',
-
         data: null,
 
         publish: {
@@ -138,6 +136,11 @@ Google Chart.
           }
         },
 
+        beforeQuerySend: function(query) {
+          query.output = 'dataTable';
+          query._src = 'gwc-ga-chart';
+        },
+
         handleResponse: function(response) {
           if (response.error) {
             this.fire('analytics-query-error', response.error);
@@ -164,7 +167,10 @@ Google Chart.
         function queryMetadataAPI() {
           return new Promise(function(resolve, reject) {
             gapi.client.analytics.metadata.columns
-                .list({reportType:'ga'})
+                .list({
+                  reportType: 'ga',
+                  _src: 'gwc-ga-chart'
+                })
                 .execute(function(response) {
                   if (response.error) {
                     reject(response.error);

--- a/google-analytics-query.html
+++ b/google-analytics-query.html
@@ -262,6 +262,8 @@ Element for querying the Google Analytics Core Reporting API.
             if (this.output) query.output = this.output;
             if (this.fields) query.fields = this.fields;
 
+            this.beforeQuerySend(query);
+
             gapi.client.analytics.data.ga.get(query)
                 .execute(this.handleResponse.bind(this));
 
@@ -283,6 +285,18 @@ Element for querying the Google Analytics Core Reporting API.
             this.data = response;
             this.fire('analytics-query-success', response);
           }
+        },
+
+        /**
+         * A hook to alter the query params object (if needed) before
+         * the request is made. This method allows subclasses to change the
+         * request without overriding the entire `getData` method.
+         *
+         * @method beforeQuerySend
+         * @param {Object} query - The query params object.
+         */
+        beforeQuerySend: function(query) {
+          query._src = 'gwt-ga-query';
         },
 
         get hasRequiredParams() {

--- a/google-analytics-view-selector.html
+++ b/google-analytics-view-selector.html
@@ -230,7 +230,10 @@ Element for selecting the view ID (ids) value for queries inside a
             var summaries = [];
             function makeRequest(startIndex) {
               gapi.client.analytics.management.accountSummaries
-                  .list({'start-index': startIndex || 1})
+                  .list({
+                    'start-index': startIndex || 1,
+                    '_src': 'gwc-ga-view-selector'
+                  })
                   .execute(ensureComplete);
             }
             function ensureComplete(resp) {


### PR DESCRIPTION
We (GA) would like to start adding a `_src` query param to all API requests from our various tools and demos to better track how they're being used and their relative popularity.

/cc @pfrisella @nickski15
