### PR TITLE
Updating to use the `google-signin-aware` component to track user

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "es6-promise": "^2.0.0",
     "ga-api-utils": "googleanalytics/javascript-api-utils#^0.1.0",
     "google-chart": "GoogleWebComponents/google-chart#^0.2.0",
-    "google-signin": "GoogleWebComponents/google-signin#^0.1.0",
+    "google-signin": "GoogleWebComponents/google-signin#^0.3.0",
     "polymer": "Polymer/polymer#^0.5.1"
   }
 }

--- a/demo.css
+++ b/demo.css
@@ -30,9 +30,7 @@ header > h1 em {
   opacity: .6;
 }
 header > google-signin {
-  color: #ccc;
   display: table-cell;
-  font-size: 1.1em;
   vertical-align: middle;
   white-space: nowrap;
 }

--- a/demo.html
+++ b/demo.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Google Analytics Polymer Elements Demo</title>
-  <script src="../webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../webcomponentsjs/webcomponents.js"></script>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:700,400,300">
   <link rel="stylesheet" href="demo.css" shim-shadowdom>
   <link rel="import" href="../google-signin/google-signin.html">
@@ -15,8 +15,7 @@
   <header>
     <h1>Google Analytics <em>Polymer Elements Demo</em></h1>
     <google-signin
-      clientId="1054047045356-j8pgqgls9vdef3rl09hapoicumbte0bo.apps.googleusercontent.com"
-      scopes="https://www.googleapis.com/auth/analytics.readonly">
+      clientId="1054047045356-j8pgqgls9vdef3rl09hapoicumbte0bo.apps.googleusercontent.com">
     </google-signin>
   </header>
 

--- a/google-analytics-base.html
+++ b/google-analytics-base.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../google-signin/google-signin-aware.html">
 <link rel="import" href="promise-import.html">
 
 <!--
@@ -17,6 +18,10 @@ intended to be used by itself. It is only intended to be subclassed.
       name="analytics"
       version="v3">
     </google-api-loader>
+    <google-signin-aware
+      scopes="https://www.googleapis.com/auth/analytics.readonly"
+      on-google-signin-aware-success="{{userAuthorized}}"
+      on-google-signin-aware-signed-out="{{userUnauthorized}}"></google-signin-aware>
   </template>
 
   <script>
@@ -66,23 +71,13 @@ intended to be used by itself. It is only intended to be subclassed.
           }
         },
 
-        created: function() {
-          document.addEventListener('google-signin-success', function(event) {
-            loadPromise
-                .then(this.userAuthorized.bind(this,event.detail.result));
-          }.bind(this));
-          document.addEventListener('google-signed-out', function(event) {
-            this.userUnauthorized();
-          }.bind(this));
-        },
-
         /**
          * The `userAuthorized` method will be invoked when the user has
          * successfully signed in and all the underlying client libraries
          * have been loaded.
          *
          * @method userAuthorized
-         * @param {Object} data - The auth data information.
+         * @param {Object} user - The auth user information.
          */
         userAuthorized: function(data) {
           this.authorized = true;
@@ -97,11 +92,7 @@ intended to be used by itself. It is only intended to be subclassed.
         userUnauthorized: function() {
           this.authorized = false;
         }
-
       });
-
     }());
-
   </script>
-
 </polymer-element>

--- a/google-analytics-base.html
+++ b/google-analytics-base.html
@@ -79,7 +79,7 @@ intended to be used by itself. It is only intended to be subclassed.
          * @method userAuthorized
          * @param {Object} user - The auth user information.
          */
-        userAuthorized: function(data) {
+        userAuthorized: function(user) {
           this.authorized = true;
         },
 


### PR DESCRIPTION
This will update to the `0.3.0` version of the `google-signin` component and add support for using the `google-signin-aware` component to track the state of the user and add the necessary scope to the normal login.