### PR TITLE
Fix JavaScript errors in the demo (closes #43)

### DIFF
--- a/google-analytics-chart.html
+++ b/google-analytics-chart.html
@@ -223,6 +223,8 @@ Google Chart.
 
       ready: function() {
         this._boundResponseHandler = this.handleResponse.bind(this);
+
+        this.$.chart.options = this.$.chart.options || {};
         merge(this.$.chart.options, getChartOptions(this.type), this.options);
       },
 

--- a/google-analytics-dashboard.html
+++ b/google-analytics-dashboard.html
@@ -79,7 +79,7 @@ update query parameters.
       },
 
       ready: function() {
-       this.updateChildren();
+        this.updateChildren();
       },
 
       /**
@@ -91,6 +91,10 @@ update query parameters.
        * @param {CustomEvent} event - The event with the query data.
        */
       queryUpdated: function(event) {
+        if (!this.query) {
+          this.query = {};
+        }
+
         // Update `this.query` with the passed event data.
         Object.keys(event.detail).forEach(function(key) {
           this.query[key] = event.detail[key];


### PR DESCRIPTION
It appears that the styling issue in #43 was caused by JavaScript errors on the page that were preventing the styles from fully loading.

I've update the code to work around these errors, but I'm a little concerned about the fact that they happened in the first place. Here's what happened:

1. Change https://github.com/GoogleWebComponents/google-chart/commit/4cd73d14fc89cfbbc10433b94353cf7e49577c2e introduced a new default value for the `options` property which broke the `<google-analytics-chart>` element. Arguably this change shouldn't have been introduced without a major version bump for this exact reason.
2. In `<google-analytics-dashboard>`, the `queryUpdated` event listener is getting called prior to the `query` property being initialized with its default value. I don't think this is WAI; it seems like it might be a bug in Polymer, though I don't have time to track down what may have caused the change in behavior.

I'm happy to have these updates merged to fix the immediate styling issue, but if someone else has an answer to the second problem above, I think it would be better to figure out the source of the problem rather than merging in a temporary hack.